### PR TITLE
Add \mainmatter

### DIFF
--- a/00-course_info.Rmd
+++ b/00-course_info.Rmd
@@ -1,3 +1,5 @@
+\mainmatter
+
 # Course information {-}
 
 [Download](https://github.com/geanders/RProgrammingForResearch/raw/master/slides/CourseOverview.pdf) a pdf of the lecture slides covering this topic.


### PR DESCRIPTION
Otherwise LaTeX does not know it should start the main matter from here, and all pages will be treated as the front matter (page numbers are roman) because of `\frontmatter` in before_body.tex introduced in 4e197a0338a589f612a0a6c3d10a64d43250dd73
